### PR TITLE
Test

### DIFF
--- a/nessus/plugins_plugin_details_test.go
+++ b/nessus/plugins_plugin_details_test.go
@@ -1,0 +1,194 @@
+package nessus
+
+import (
+	"testing"
+)
+
+// TestClient_PluginsPluginDetails tests the PluginsPluginDetails method of the Client
+func TestClient_PluginsPluginDetails(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		id      int
+		wantErr bool
+	}{
+		{
+			name: "success with valid plugin id and api keys",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			id:      19506,
+			wantErr: false,
+		},
+		{
+			name: "success with different plugin id and token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("0d243c20662ba2335828d99dfb65f5817887611f2ceb9bf3"),
+			},
+			id:      10107,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid credentials using token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid_token"),
+			},
+			id:      19506,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid credentials using api keys",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"invalid_access_key",
+					"invalid_secret_key",
+				),
+			},
+			id:      19506,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			id:      19506,
+			wantErr: true,
+		},
+		{
+			name: "error with negative plugin id",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			id:      -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero plugin id",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			id:      0,
+			wantErr: true,
+		},
+		{
+			name: "error with very large plugin id",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			id:      99999999999,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+
+			got, err := c.PluginsPluginDetails(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PluginsPluginDetails() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("PluginsPluginDetails() got = %v, want non-nil", got)
+			}
+			if !tt.wantErr && got != nil {
+				// Verify that the response has expected fields
+				if got.ID != tt.id {
+					t.Errorf("PluginsPluginDetails() got ID = %v, want ID = %v", got.ID, tt.id)
+				}
+				if got.Name == "" {
+					t.Errorf("PluginsPluginDetails() got Name = %v, want non-empty name", got.Name)
+				}
+				if got.FamilyName == "" {
+					t.Errorf("PluginsPluginDetails() got FamilyName = %v, want non-empty family name", got.FamilyName)
+				}
+
+				// Check that attributes are properly initialized
+				if got.Attributes == nil {
+					t.Errorf("PluginsPluginDetails() got Attributes = nil, want non-nil attributes")
+				} else {
+					// If there are attributes, verify they have expected fields
+					for i, attr := range got.Attributes {
+						if attr.AttributeName == "" {
+							t.Errorf("PluginsPluginDetails() got.Attributes[%d].AttributeName = %v, want non-empty name", i, attr.AttributeName)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestClient_PluginsPluginDetails_NetworkError tests error handling when network issues occur
+func TestClient_PluginsPluginDetails_NetworkError(t *testing.T) {
+	// Test with an unreachable URL to trigger network error
+	c, err := NewClient(
+		WithAPIURL("https://unreachable-url-for-testing:8834"),
+		WithAPIKey(
+			"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+			"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	got, err := c.PluginsPluginDetails(19506)
+	if err == nil {
+		t.Errorf("PluginsPluginDetails() expected error for unreachable URL, got nil")
+	}
+	if got != nil {
+		t.Errorf("PluginsPluginDetails() expected nil response for network error, got = %v", got)
+	}
+}
+
+// TestClient_PluginsPluginDetails_HTTPError tests error handling when HTTP errors occur
+func TestClient_PluginsPluginDetails_HTTPError(t *testing.T) {
+	// Note: This test will likely require mocking to properly test HTTP error responses
+	// For now, we're testing that the function handles non-200 status codes properly
+	// by checking the ErrorResponse function behavior
+	c, err := NewClient(
+		WithAPIURL("https://localhost:8834"),
+		WithAPIKey(
+			"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+			"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+		),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	// Using an ID that is likely to return a 404 or other error status
+	got, err := c.PluginsPluginDetails(999999)
+	if err == nil {
+		// If no error occurred, that's fine, but we should still check the response
+		if got != nil && got.ID != 99999 {
+			t.Errorf("PluginsPluginDetails() got ID = %v, want ID = %v", got.ID, 999999)
+		}
+	}
+	// If an error occurred, that's also acceptable as it would be an HTTP error response
+}

--- a/nessus/scans_attachment_prepare_test.go
+++ b/nessus/scans_attachment_prepare_test.go
@@ -1,0 +1,225 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansAttachmentPrepare(t *testing.T) {
+	type args struct {
+		param   *ScansAttachmentPrepareParam
+		request *ScansAttachmentPrepareRequest
+		options []Option
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "success_with_history_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success_without_history_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       2,
+					AttachmentID: 2,
+				},
+				request: &ScansAttachmentPrepareRequest{},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error_missing_api_key",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error_invalid_scan_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       -1,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error_invalid_attachment_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: -1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error_zero_scan_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       0,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error_zero_attachment_id",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 0,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error_empty_request",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 1,
+				},
+				request: nil,
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithAPIKey(
+						"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+						"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+					),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success_with_token_auth",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithToken("62977d0ee34a809c6011d8afa0f037f5698f08c25829a74a"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error_with_invalid_token",
+			args: args{
+				param: &ScansAttachmentPrepareParam{
+					ScanID:       1,
+					AttachmentID: 1,
+				},
+				request: &ScansAttachmentPrepareRequest{
+					HistoryID: 123,
+				},
+				options: []Option{
+					WithAPIURL("https://localhost:8834"),
+					WithToken("invalid-token"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.args.options...)
+			if err != nil && !tt.wantErr {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+
+			got, err := c.ScansAttachmentPrepare(tt.args.param, tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansAttachmentPrepare() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && got == nil {
+				t.Errorf("ScansAttachmentPrepare() got = %v, want non-nil result", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_configure_test.go
+++ b/nessus/scans_configure_test.go
@@ -1,0 +1,1124 @@
+package nessus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestClient_ScansConfigure(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		request *ScansConfigureRequest
+		wantErr bool
+	}{
+		{
+			name: "success configuration update with API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Test Scan",
+					Description: "Test Description",
+					PolicyID:    1,
+					FolderID:    2,
+					Enabled:     true,
+					Launch:      "ONETIME",
+					TextTargets: []string{"192.168.1.1"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success configuration update with session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("valid-session-token"),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Token Auth Test",
+					Description: "Test with token authentication",
+					PolicyID:    1,
+					TextTargets: []string{"10.0.0.1"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with complete configuration",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID: 10,
+			request: &ScansConfigureRequest{
+				UUID: "complete-test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:         "Complete Configuration Test",
+					Description:  "Full configuration with all parameters",
+					PolicyID:     5,
+					FolderID:     3,
+					ScannerID:    2,
+					Enabled:      true,
+					Launch:       "RECURRING",
+					Starttime:    "20240101T120000",
+					Rrules:       "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO",
+					Timezone:     "America/New_York",
+					TargetGroups: []string{"group1", "group2"},
+					AgentGroups:  []string{"agent1", "agent2"},
+					TextTargets:  []string{"192.168.1.0/24", "10.0.0.0/8"},
+					FileTargets:  []string{"targets.txt"},
+					Emails:       "admin@example.com,user@example.com",
+					Acls: []*PermissionResource{
+						{
+							Type:        "user",
+							Permissions: 64,
+							ID:          123,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error invalid scan ID negative",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID: -1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error invalid scan ID zero",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID: 0,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error without authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid-key", "invalid-secret"),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with expired session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("expired-session-token"),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Test Scan",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID:  1,
+			request: nil,
+			wantErr: true,
+		},
+		{
+			name: "error with nil settings",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
+					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+				),
+			},
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID:     "test-uuid",
+				Settings: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "error unauthorized access",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"unauthorized-access-key",
+					"unauthorized-secret-key",
+				),
+			},
+			scanID: 999999,
+			request: &ScansConfigureRequest{
+				UUID: "test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name: "Unauthorized Test",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+
+			got, err := c.ScansConfigure(tt.scanID, tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansConfigure() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansConfigure() got = %v, want non-nil", got)
+			}
+		})
+	}
+}
+
+func TestScansConfigureRequestValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *ScansConfigureRequest
+		expectValid bool
+	}{
+		{
+			name: "valid request with all fields",
+			request: &ScansConfigureRequest{
+				UUID: "valid-uuid-12345",
+				Settings: &ScansConfigureSetting{
+					Name:         "Complete Test Scan",
+					Description:  "Full configuration test",
+					PolicyID:     10,
+					FolderID:     5,
+					ScannerID:    3,
+					Enabled:      true,
+					Launch:       "RECURRING",
+					Starttime:    "20240101T120000",
+					Rrules:       "FREQ=DAILY;INTERVAL=1",
+					Timezone:     "UTC",
+					TargetGroups: []string{"group1", "group2"},
+					AgentGroups:  []string{"agent1", "agent2"},
+					TextTargets:  []string{"192.168.1.1", "10.0.0.1"},
+					FileTargets:  []string{"targets.txt", "hosts.csv"},
+					Emails:       "admin@example.com",
+					Acls: []*PermissionResource{
+						{
+							Type:        "user",
+							Permissions: 64,
+							ID:          123,
+						},
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with minimal fields",
+			request: &ScansConfigureRequest{
+				UUID: "minimal-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Minimal Scan",
+					TextTargets: []string{"127.0.0.1"},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with empty name",
+			request: &ScansConfigureRequest{
+				UUID: "empty-name-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "",
+					TextTargets: []string{"192.168.1.1"},
+				},
+			},
+			expectValid: true, // Validation happens server-side
+		},
+		{
+			name: "valid request with multiple target groups",
+			request: &ScansConfigureRequest{
+				UUID: "multi-target-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:         "Multi Target Scan",
+					TargetGroups: []string{"group1", "group2", "group3", "group4"},
+					TextTargets:  []string{"10.0.0.1"},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with multiple agent groups",
+			request: &ScansConfigureRequest{
+				UUID: "multi-agent-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Multi Agent Scan",
+					AgentGroups: []string{"agent1", "agent2", "agent3"},
+					TextTargets: []string{"172.16.0.1"},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with email notifications",
+			request: &ScansConfigureRequest{
+				UUID: "email-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Email Notification Scan",
+					Emails:      "user1@example.com,user2@example.com,admin@example.com",
+					TextTargets: []string{"192.168.1.100"},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with schedule settings",
+			request: &ScansConfigureRequest{
+				UUID: "schedule-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Scheduled Scan",
+					Launch:      "RECURRING",
+					Starttime:   "20240315T140000",
+					Rrules:      "FREQ=WEEKLY;INTERVAL=2;BYDAY=FR",
+					Timezone:    "America/Los_Angeles",
+					TextTargets: []string{"10.10.10.10"},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with ACL permissions",
+			request: &ScansConfigureRequest{
+				UUID: "acl-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "ACL Test Scan",
+					TextTargets: []string{"192.168.1.50"},
+					Acls: []*PermissionResource{
+						{
+							Type:        "user",
+							Permissions: 32,
+							ID:          456,
+						},
+						{
+							Type:        "group",
+							Permissions: 16,
+							ID:          789,
+						},
+					},
+				},
+			},
+			expectValid: true,
+		},
+		{
+			name: "valid request with empty arrays",
+			request: &ScansConfigureRequest{
+				UUID: "empty-arrays-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:         "Empty Arrays Scan",
+					TargetGroups: []string{},
+					AgentGroups:  []string{},
+					TextTargets:  []string{"192.168.1.200"},
+					FileTargets:  []string{},
+					Acls:         []*PermissionResource{},
+				},
+			},
+			expectValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that the struct can be marshaled/unmarshaled
+			data, err := sonic.Marshal(tt.request)
+			if err != nil && tt.expectValid {
+				t.Errorf("Expected valid request, but marshaling failed: %v", err)
+				return
+			}
+			if err == nil && !tt.expectValid {
+				t.Errorf("Expected invalid request, but marshaling succeeded")
+				return
+			}
+
+			if tt.expectValid {
+				var unmarshaled ScansConfigureRequest
+				err = sonic.Unmarshal(data, &unmarshaled)
+				if err != nil {
+					t.Errorf("Failed to unmarshal valid request: %v", err)
+					return
+				}
+
+				// Verify key fields are preserved
+				if unmarshaled.UUID != tt.request.UUID {
+					t.Errorf("UUID mismatch: got %s, want %s", unmarshaled.UUID, tt.request.UUID)
+				}
+				if unmarshaled.Settings != nil && tt.request.Settings != nil {
+					if unmarshaled.Settings.Name != tt.request.Settings.Name {
+						t.Errorf("Name mismatch: got %s, want %s", unmarshaled.Settings.Name, tt.request.Settings.Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestScansConfigureSettingValidation(t *testing.T) {
+	settings := []struct {
+		name     string
+		setting  *ScansConfigureSetting
+		expected string
+	}{
+		{
+			name: "basic scan setting",
+			setting: &ScansConfigureSetting{
+				Name:        "Basic Configuration",
+				Description: "A basic scan configuration test",
+				TextTargets: []string{"192.168.1.1"},
+			},
+			expected: "Basic Configuration",
+		},
+		{
+			name: "setting with policy and folder",
+			setting: &ScansConfigureSetting{
+				Name:        "Policy and Folder Test",
+				Description: "Test with specific policy and folder",
+				PolicyID:    15,
+				FolderID:    8,
+				Enabled:     true,
+				Launch:      "ONETIME",
+				TextTargets: []string{"192.168.1.0/24"},
+			},
+			expected: "Policy and Folder Test",
+		},
+		{
+			name: "setting with scanner specification",
+			setting: &ScansConfigureSetting{
+				Name:        "Scanner Specific Test",
+				ScannerID:   7,
+				TextTargets: []string{"10.0.0.0/16"},
+			},
+			expected: "Scanner Specific Test",
+		},
+		{
+			name: "setting with target and agent groups",
+			setting: &ScansConfigureSetting{
+				Name:         "Group-based Scan",
+				TargetGroups: []string{"WebServers", "DatabaseServers"},
+				AgentGroups:  []string{"LinuxAgents", "WindowsAgents"},
+			},
+			expected: "Group-based Scan",
+		},
+		{
+			name: "setting with scheduling",
+			setting: &ScansConfigureSetting{
+				Name:        "Scheduled Scan Test",
+				Launch:      "RECURRING",
+				Starttime:   "20240401T080000",
+				Rrules:      "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=1",
+				Timezone:    "Europe/London",
+				TextTargets: []string{"172.16.0.0/12"},
+			},
+			expected: "Scheduled Scan Test",
+		},
+		{
+			name: "setting with file targets",
+			setting: &ScansConfigureSetting{
+				Name:        "File Target Test",
+				FileTargets: []string{"production_hosts.txt", "staging_hosts.csv"},
+				TextTargets: []string{"192.168.100.1"},
+			},
+			expected: "File Target Test",
+		},
+		{
+			name: "setting with notifications",
+			setting: &ScansConfigureSetting{
+				Name:        "Notification Test",
+				Emails:      "security@company.com,ops@company.com",
+				TextTargets: []string{"10.20.30.40"},
+			},
+			expected: "Notification Test",
+		},
+		{
+			name: "setting with complex ACLs",
+			setting: &ScansConfigureSetting{
+				Name:        "Complex ACL Test",
+				TextTargets: []string{"172.16.1.1"},
+				Acls: []*PermissionResource{
+					{
+						Type:        "user",
+						Permissions: 128,
+						ID:          1001,
+					},
+					{
+						Type:        "group",
+						Permissions: 64,
+						ID:          2001,
+					},
+					{
+						Type:        "user",
+						Permissions: 32,
+						ID:          1002,
+					},
+				},
+			},
+			expected: "Complex ACL Test",
+		},
+	}
+
+	for _, tt := range settings {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			data, err := sonic.Marshal(tt.setting)
+			if err != nil {
+				t.Errorf("Failed to marshal setting: %v", err)
+				return
+			}
+
+			// Test unmarshaling
+			var unmarshaled ScansConfigureSetting
+			err = sonic.Unmarshal(data, &unmarshaled)
+			if err != nil {
+				t.Errorf("Failed to unmarshal setting: %v", err)
+				return
+			}
+
+			if unmarshaled.Name != tt.expected {
+				t.Errorf("Expected name %s, got %s", tt.expected, unmarshaled.Name)
+			}
+
+			// Verify arrays are properly handled
+			if len(tt.setting.TextTargets) > 0 && len(unmarshaled.TextTargets) != len(tt.setting.TextTargets) {
+				t.Errorf("TextTargets length mismatch: got %d, want %d", len(unmarshaled.TextTargets), len(tt.setting.TextTargets))
+			}
+
+			if len(tt.setting.TargetGroups) > 0 && len(unmarshaled.TargetGroups) != len(tt.setting.TargetGroups) {
+				t.Errorf("TargetGroups length mismatch: got %d, want %d", len(unmarshaled.TargetGroups), len(tt.setting.TargetGroups))
+			}
+
+			if len(tt.setting.AgentGroups) > 0 && len(unmarshaled.AgentGroups) != len(tt.setting.AgentGroups) {
+				t.Errorf("AgentGroups length mismatch: got %d, want %d", len(unmarshaled.AgentGroups), len(tt.setting.AgentGroups))
+			}
+
+			if len(tt.setting.Acls) > 0 && len(unmarshaled.Acls) != len(tt.setting.Acls) {
+				t.Errorf("Acls length mismatch: got %d, want %d", len(unmarshaled.Acls), len(tt.setting.Acls))
+			}
+		})
+	}
+}
+
+// Test edge cases for scan configuration
+func TestScansConfigure_EdgeCases(t *testing.T) {
+	t.Run("empty configuration", func(t *testing.T) {
+		request := &ScansConfigureRequest{
+			Settings: &ScansConfigureSetting{},
+		}
+
+		// Verify the request can be marshaled/unmarshaled
+		data, err := sonic.Marshal(request)
+		if err != nil {
+			t.Errorf("Failed to marshal empty configuration: %v", err)
+		}
+
+		var unmarshaled ScansConfigureRequest
+		err = sonic.Unmarshal(data, &unmarshaled)
+		if err != nil {
+			t.Errorf("Failed to unmarshal empty configuration: %v", err)
+		}
+	})
+
+	t.Run("large configuration", func(t *testing.T) {
+		// Create large arrays for testing
+		var largeTargetGroups []string
+		var largeAgentGroups []string
+		var largeTextTargets []string
+		var largeFileTargets []string
+		var largeAcls []*PermissionResource
+
+		for i := 0; i < 100; i++ {
+			largeTargetGroups = append(largeTargetGroups, fmt.Sprintf("TargetGroup%d", i))
+			largeAgentGroups = append(largeAgentGroups, fmt.Sprintf("AgentGroup%d", i))
+			largeTextTargets = append(largeTextTargets, fmt.Sprintf("192.168.%d.1", i))
+			largeFileTargets = append(largeFileTargets, fmt.Sprintf("targets%d.txt", i))
+			largeAcls = append(largeAcls, &PermissionResource{
+				Type:        "user",
+				Permissions: 32,
+				ID:          1000 + i,
+			})
+		}
+
+		request := &ScansConfigureRequest{
+			UUID: "large-configuration-uuid-with-very-long-string-for-testing-purposes-and-edge-cases",
+			Settings: &ScansConfigureSetting{
+				Name:         "Large Configuration Test with Very Long Name for Edge Case Testing",
+				Description:  "Very long description that tests the limits of the configuration system and ensures that large amounts of text can be properly handled by the marshaling and unmarshaling processes without causing errors or data corruption",
+				PolicyID:     999999,
+				FolderID:     888888,
+				ScannerID:    777777,
+				Enabled:      true,
+				Launch:       "RECURRING",
+				Starttime:    "20241201T235959",
+				Rrules:       "FREQ=DAILY;INTERVAL=1;BYHOUR=0,6,12,18;BYMINUTE=0,15,30,45",
+				Timezone:     "America/New_York",
+				TargetGroups: largeTargetGroups,
+				AgentGroups:  largeAgentGroups,
+				TextTargets:  largeTextTargets,
+				FileTargets:  largeFileTargets,
+				Emails:       "admin@example.com,user1@example.com,user2@example.com,user3@example.com,user4@example.com,user5@example.com",
+				Acls:         largeAcls,
+			},
+		}
+
+		// Verify the request can be marshaled/unmarshaled
+		data, err := sonic.Marshal(request)
+		if err != nil {
+			t.Errorf("Failed to marshal large configuration: %v", err)
+		}
+
+		var unmarshaled ScansConfigureRequest
+		err = sonic.Unmarshal(data, &unmarshaled)
+		if err != nil {
+			t.Errorf("Failed to unmarshal large configuration: %v", err)
+		}
+
+		// Verify array lengths
+		if len(unmarshaled.Settings.TargetGroups) != 100 {
+			t.Errorf("Expected 100 target groups, got %d", len(unmarshaled.Settings.TargetGroups))
+		}
+		if len(unmarshaled.Settings.AgentGroups) != 100 {
+			t.Errorf("Expected 100 agent groups, got %d", len(unmarshaled.Settings.AgentGroups))
+		}
+		if len(unmarshaled.Settings.TextTargets) != 100 {
+			t.Errorf("Expected 100 text targets, got %d", len(unmarshaled.Settings.TextTargets))
+		}
+	})
+
+	t.Run("special characters in configuration", func(t *testing.T) {
+		request := &ScansConfigureRequest{
+			UUID: "special-chars-测试-🔒-uuid",
+			Settings: &ScansConfigureSetting{
+				Name:        "Special Characters Test: 測試 🔒 «»‹› ñáéíóú",
+				Description: "Test with special characters: #$%^&*(){}[]|\\:;\"'<>,.?/~`+=_-",
+				TextTargets: []string{"192.168.1.1"},
+				Emails:      "test+special@example.com,user.name@sub-domain.example.org",
+			},
+		}
+
+		// Verify the request can be marshaled/unmarshaled
+		data, err := sonic.Marshal(request)
+		if err != nil {
+			t.Errorf("Failed to marshal special characters configuration: %v", err)
+		}
+
+		var unmarshaled ScansConfigureRequest
+		err = sonic.Unmarshal(data, &unmarshaled)
+		if err != nil {
+			t.Errorf("Failed to unmarshal special characters configuration: %v", err)
+		}
+
+		if unmarshaled.Settings.Name != request.Settings.Name {
+			t.Errorf("Special characters in name not preserved: got %s, want %s", unmarshaled.Settings.Name, request.Settings.Name)
+		}
+	})
+
+	t.Run("minimal valid configuration", func(t *testing.T) {
+		request := &ScansConfigureRequest{
+			UUID: "min",
+			Settings: &ScansConfigureSetting{
+				Name:        "M",
+				TextTargets: []string{"1.1.1.1"},
+			},
+		}
+
+		// Verify the request can be marshaled/unmarshaled
+		data, err := sonic.Marshal(request)
+		if err != nil {
+			t.Errorf("Failed to marshal minimal configuration: %v", err)
+		}
+
+		var unmarshaled ScansConfigureRequest
+		err = sonic.Unmarshal(data, &unmarshaled)
+		if err != nil {
+			t.Errorf("Failed to unmarshal minimal configuration: %v", err)
+		}
+	})
+}
+
+func TestScansConfigureResponseValidation(t *testing.T) {
+	// Test the response structure
+	response := &ScansConfigureResponse{
+		CreationDate:           1640995200,
+		CustomTargets:          "192.168.1.1,10.0.0.1",
+		DefaultPermissions:     64,
+		Description:            "Test scan configuration response",
+		Emails:                 "admin@example.com,user@example.com",
+		ID:                     12345,
+		LastModificationDate:   1640995800,
+		Name:                   "Test Configured Scan",
+		NotificationFilters:    "all",
+		NotificationFilterType: "default",
+		Owner:                  "admin",
+		OwnerID:                1,
+		PolicyID:               10,
+		Rrules:                 "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO",
+		Shared:                 1,
+		Starttime:              "20240101T120000",
+		TagID:                  5,
+		Timezone:               "UTC",
+		Type:                   "public",
+		UserPermissions:        128,
+		UUID:                   "response-test-uuid",
+	}
+
+	// Test marshaling
+	data, err := sonic.Marshal(response)
+	if err != nil {
+		t.Errorf("Failed to marshal response: %v", err)
+		return
+	}
+
+	// Test unmarshaling
+	var unmarshaled ScansConfigureResponse
+	err = sonic.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Errorf("Failed to unmarshal response: %v", err)
+		return
+	}
+
+	// Verify key fields
+	if unmarshaled.Name != "Test Configured Scan" {
+		t.Errorf("Expected name 'Test Configured Scan', got '%s'", unmarshaled.Name)
+	}
+	if unmarshaled.ID != 12345 {
+		t.Errorf("Expected ID 12345, got %d", unmarshaled.ID)
+	}
+	if unmarshaled.UUID != "response-test-uuid" {
+		t.Errorf("Expected UUID 'response-test-uuid', got '%s'", unmarshaled.UUID)
+	}
+	if unmarshaled.PolicyID != 10 {
+		t.Errorf("Expected PolicyID 10, got %d", unmarshaled.PolicyID)
+	}
+}
+
+func TestScansConfigure_AuthenticationMethods(t *testing.T) {
+	baseRequest := &ScansConfigureRequest{
+		UUID: "auth-test-uuid",
+		Settings: &ScansConfigureSetting{
+			Name:        "Authentication Test",
+			TextTargets: []string{"127.0.0.1"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		options     []Option
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid API key authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"valid-access-key-1234567890abcdef1234567890abcdef12345678",
+					"valid-secret-key-1234567890abcdef1234567890abcdef12345678",
+				),
+			},
+			expectError: false,
+			description: "Should succeed with valid API keys",
+		},
+		{
+			name: "valid session token authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("valid-session-token-1234567890abcdef"),
+			},
+			expectError: false,
+			description: "Should succeed with valid session token",
+		},
+		{
+			name: "invalid API key authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "keys"),
+			},
+			expectError: true,
+			description: "Should fail with invalid API keys",
+		},
+		{
+			name: "empty API key authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("", ""),
+			},
+			expectError: true,
+			description: "Should fail with empty API keys",
+		},
+		{
+			name: "invalid session token authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			expectError: true,
+			description: "Should fail with invalid session token",
+		},
+		{
+			name: "empty session token authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken(""),
+			},
+			expectError: true,
+			description: "Should fail with empty session token",
+		},
+		{
+			name: "no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			expectError: true,
+			description: "Should fail with no authentication",
+		},
+		{
+			name: "mixed authentication methods",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("access-key", "secret-key"),
+				WithToken("session-token"),
+			},
+			expectError: false,
+			description: "Should use API key when both are provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+
+			_, err = c.ScansConfigure(1, baseRequest)
+			if (err != nil) != tt.expectError {
+				t.Errorf("ScansConfigure() error = %v, expectError %v - %s", err, tt.expectError, tt.description)
+			}
+		})
+	}
+}
+
+func TestScansConfigure_SecurityTests(t *testing.T) {
+	tests := []struct {
+		name        string
+		scanID      int
+		request     *ScansConfigureRequest
+		description string
+	}{
+		{
+			name:   "scan ID boundary test - max int",
+			scanID: 2147483647, // max int32
+			request: &ScansConfigureRequest{
+				UUID: "boundary-test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Boundary Test",
+					TextTargets: []string{"192.168.1.1"},
+				},
+			},
+			description: "Test with maximum integer scan ID",
+		},
+		{
+			name:   "large scan ID",
+			scanID: 999999999,
+			request: &ScansConfigureRequest{
+				UUID: "large-id-test-uuid",
+				Settings: &ScansConfigureSetting{
+					Name:        "Large ID Test",
+					TextTargets: []string{"10.0.0.1"},
+				},
+			},
+			description: "Test with very large scan ID",
+		},
+		{
+			name:   "injection attempt in UUID",
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "'; DROP TABLE scans; --",
+				Settings: &ScansConfigureSetting{
+					Name:        "Injection Test",
+					TextTargets: []string{"127.0.0.1"},
+				},
+			},
+			description: "Test SQL injection attempt in UUID field",
+		},
+		{
+			name:   "injection attempt in name",
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "injection-name-test",
+				Settings: &ScansConfigureSetting{
+					Name:        "<script>alert('xss')</script>",
+					Description: "../../etc/passwd",
+					TextTargets: []string{"192.168.1.1"},
+				},
+			},
+			description: "Test XSS and path traversal in name/description",
+		},
+		{
+			name:   "malicious targets",
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "malicious-targets-test",
+				Settings: &ScansConfigureSetting{
+					Name:        "Malicious Targets Test",
+					TextTargets: []string{"../../../etc/passwd", "$(rm -rf /)", "0.0.0.0/0"},
+				},
+			},
+			description: "Test with potentially malicious target specifications",
+		},
+		{
+			name:   "malicious email addresses",
+			scanID: 1,
+			request: &ScansConfigureRequest{
+				UUID: "malicious-email-test",
+				Settings: &ScansConfigureSetting{
+					Name:        "Email Test",
+					Emails:      "test@example.com\r\nBcc: hacker@malicious.com",
+					TextTargets: []string{"127.0.0.1"},
+				},
+			},
+			description: "Test email header injection attempt",
+		},
+	}
+
+	// These tests verify that the data structures can handle potentially malicious input
+	// without crashing. Server-side validation should handle security concerns.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that potentially malicious input can be marshaled/unmarshaled safely
+			data, err := sonic.Marshal(tt.request)
+			if err != nil {
+				t.Errorf("Failed to marshal potentially malicious request: %v", err)
+				return
+			}
+
+			var unmarshaled ScansConfigureRequest
+			err = sonic.Unmarshal(data, &unmarshaled)
+			if err != nil {
+				t.Errorf("Failed to unmarshal potentially malicious request: %v", err)
+				return
+			}
+
+			// Verify that the data is preserved as-is (security validation happens server-side)
+			if unmarshaled.UUID != tt.request.UUID {
+				t.Errorf("UUID not preserved: got %s, want %s", unmarshaled.UUID, tt.request.UUID)
+			}
+		})
+	}
+}
+
+func TestScansConfigure_ParameterValidation(t *testing.T) {
+	// Test various parameter combinations and edge cases
+	tests := []struct {
+		name     string
+		settings *ScansConfigureSetting
+		valid    bool
+	}{
+		{
+			name: "valid launch types",
+			settings: &ScansConfigureSetting{
+				Name:        "Launch Type Test",
+				Launch:      "ONETIME",
+				TextTargets: []string{"192.168.1.1"},
+			},
+			valid: true,
+		},
+		{
+			name: "valid recurring launch",
+			settings: &ScansConfigureSetting{
+				Name:        "Recurring Test",
+				Launch:      "RECURRING",
+				Starttime:   "20240101T120000",
+				Rrules:      "FREQ=DAILY;INTERVAL=1",
+				TextTargets: []string{"10.0.0.1"},
+			},
+			valid: true,
+		},
+		{
+			name: "timezone validation",
+			settings: &ScansConfigureSetting{
+				Name:        "Timezone Test",
+				Timezone:    "America/New_York",
+				TextTargets: []string{"172.16.0.1"},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid timezone format",
+			settings: &ScansConfigureSetting{
+				Name:        "Invalid Timezone Test",
+				Timezone:    "Invalid/Timezone",
+				TextTargets: []string{"192.168.1.1"},
+			},
+			valid: true, // Client-side allows any string, server validates
+		},
+		{
+			name: "policy ID validation",
+			settings: &ScansConfigureSetting{
+				Name:        "Policy ID Test",
+				PolicyID:    -1, // Negative policy ID
+				TextTargets: []string{"10.0.0.1"},
+			},
+			valid: true, // Client allows, server validates
+		},
+		{
+			name: "folder ID validation",
+			settings: &ScansConfigureSetting{
+				Name:        "Folder ID Test",
+				FolderID:    0, // Zero folder ID
+				TextTargets: []string{"172.16.0.1"},
+			},
+			valid: true,
+		},
+		{
+			name: "scanner ID validation",
+			settings: &ScansConfigureSetting{
+				Name:        "Scanner ID Test",
+				ScannerID:   999999, // Very large scanner ID
+				TextTargets: []string{"192.168.1.1"},
+			},
+			valid: true,
+		},
+		{
+			name: "empty target arrays",
+			settings: &ScansConfigureSetting{
+				Name:         "Empty Arrays Test",
+				TargetGroups: []string{},
+				AgentGroups:  []string{},
+				TextTargets:  []string{},
+				FileTargets:  []string{},
+			},
+			valid: true,
+		},
+		{
+			name: "nil target arrays",
+			settings: &ScansConfigureSetting{
+				Name:         "Nil Arrays Test",
+				TargetGroups: nil,
+				AgentGroups:  nil,
+				TextTargets:  nil,
+				FileTargets:  nil,
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &ScansConfigureRequest{
+				UUID:     "param-validation-test",
+				Settings: tt.settings,
+			}
+
+			data, err := sonic.Marshal(request)
+			if err != nil && tt.valid {
+				t.Errorf("Expected valid configuration, but marshaling failed: %v", err)
+				return
+			}
+			if err == nil && !tt.valid {
+				t.Errorf("Expected invalid configuration, but marshaling succeeded")
+				return
+			}
+
+			if tt.valid {
+				var unmarshaled ScansConfigureRequest
+				err = sonic.Unmarshal(data, &unmarshaled)
+				if err != nil {
+					t.Errorf("Failed to unmarshal valid configuration: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/nessus/scans_copy_test.go
+++ b/nessus/scans_copy_test.go
@@ -1,0 +1,138 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansCopy(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		request *ScansCopyRequest
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: &ScansCopyRequest{Name: "Copy of Scan", FolderID: 2},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			request: &ScansCopyRequest{Name: "Token Copy", FolderID: 3},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			request: &ScansCopyRequest{Name: "Invalid Key", FolderID: 2},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			request: &ScansCopyRequest{Name: "Invalid Token", FolderID: 2},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			request: &ScansCopyRequest{Name: "No Auth", FolderID: 2},
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			request: &ScansCopyRequest{Name: "Negative ID", FolderID: 2},
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			request: &ScansCopyRequest{Name: "Zero ID", FolderID: 2},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: nil,
+			wantErr: true,
+		},
+		{
+			name: "error with empty request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: &ScansCopyRequest{},
+			wantErr: true, // Accepts empty request, server may handle validation
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansCopy(tt.scanID, tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansCopy() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansCopy() got = %v, want non-nil", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_create.go
+++ b/nessus/scans_create.go
@@ -21,12 +21,12 @@ type ScansCreateSetting struct {
 }
 
 type ScansCreateRequest struct {
-	UUID     string              `json:"uuid,omitempty"`
-	Settings *ScansCreateSetting `json:"settings,omitempty"`
+	TemplateUUID string              `json:"uuid,omitempty"`
+	Settings     *ScansCreateSetting `json:"settings,omitempty"`
 }
 
 type ScanResult struct {
-	Creationdate           int    `json:"creation_date,omitempty"`
+	CreationDate           int    `json:"creation_date,omitempty"`
 	CustomTargets          string `json:"custom_targets,omitempty"`
 	DefaultPermissions     int    `json:"default_permissions,omitempty"`
 	Description            string `json:"description,omitempty"`

--- a/nessus/scans_create_test.go
+++ b/nessus/scans_create_test.go
@@ -1,0 +1,166 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansCreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		request *ScansCreateRequest
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "b8cb1f88-3688-4085-b145-82f5e4ca04cf",
+				Settings: &ScansCreateSetting{
+					Name:        "API Key Scan",
+					Description: "Scan created with API key",
+					FolderID:    "2",
+					PolicyID:    "1",
+					TextTargets: "sv.haui.edu.vn",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "b32eb026-2288-4db3-abbd-081934e5144d",
+				Settings: &ScansCreateSetting{
+					Name:        "Token Scan",
+					Description: "Scan created with token",
+					FolderID:    "3",
+					PolicyID:    "2",
+					TextTargets: "yoasobi.com",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "invalid-api-key",
+				Settings: &ScansCreateSetting{
+					Name:        "Invalid Key",
+					FolderID:    "2",
+					PolicyID:    "1",
+					TextTargets: "192.168.1.1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "invalid-token",
+				Settings: &ScansCreateSetting{
+					Name:        "Invalid Token",
+					FolderID:    "2",
+					PolicyID:    "1",
+					TextTargets: "192.168.1.1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "no-auth",
+				Settings: &ScansCreateSetting{
+					Name:        "No Auth",
+					FolderID:    "2",
+					PolicyID:    "1",
+					TextTargets: "192.168.1.1",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			request: nil,
+			wantErr: true,
+		},
+		{
+			name: "error with empty request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			request: &ScansCreateRequest{},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid scan parameters",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			request: &ScansCreateRequest{
+				TemplateUUID: "invalid-params",
+				Settings: &ScansCreateSetting{
+					Name:        "",
+					FolderID:    "-1",
+					PolicyID:    "not-a-number",
+					TextTargets: "",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansCreate(tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansCreate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (got == nil || got.Scan == nil) {
+				t.Errorf("ScansCreate() got = %v, want non-nil ScanResult", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_delete_bulk_test.go
+++ b/nessus/scans_delete_bulk_test.go
@@ -1,0 +1,104 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansDeleteBulk(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		ids     []int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			ids:     []int{1, 2, 3},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			ids:     []int{4, 5},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			ids:     []int{1, 2},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			ids:     []int{1, 2},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			ids:     []int{1, 2},
+			wantErr: true,
+		},
+		{
+			name: "error with empty IDs",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			ids:     []int{},
+			wantErr: true,
+		},
+		{
+			name: "error with negative ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			ids:     []int{-1, 2},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansDeleteBulk(tt.ids)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansDeleteBulk() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (got == nil || len(got.Deleted) == 0) {
+				t.Errorf("ScansDeleteBulk() got = %v, want non-nil Deleted", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_delete_history_test.go
+++ b/nessus/scans_delete_history_test.go
@@ -1,0 +1,108 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansDeleteHistory(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   []Option
+		scanID    int
+		historyID int
+		wantErr   bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:    1,
+			historyID: 10,
+			wantErr:   false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:    2,
+			historyID: 20,
+			wantErr:   false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:    1,
+			historyID: 10,
+			wantErr:   true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:    1,
+			historyID: 10,
+			wantErr:   true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:    1,
+			historyID: 10,
+			wantErr:   true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:    -1,
+			historyID: 10,
+			wantErr:   true,
+		},
+		{
+			name: "error with negative history ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:    1,
+			historyID: -10,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansDeleteHistory(tt.scanID, tt.historyID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansDeleteHistory() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_delete_test.go
+++ b/nessus/scans_delete_test.go
@@ -1,0 +1,100 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansDelete(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansDelete(tt.scanID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansDelete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_details_test.go
+++ b/nessus/scans_details_test.go
@@ -1,0 +1,125 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansDetails(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		query   *ScansDetailsQuery
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			query:   &ScansDetailsQuery{HistoryID: 0, Limit: 0},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			query:   &ScansDetailsQuery{HistoryID: 0, Limit: 0},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+		{
+			name: "error with large scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  999999999,
+			query:   &ScansDetailsQuery{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansDetails(tt.scanID, tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansDetails() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansDetails() got = %v, want non-nil", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_export_status_test.go
+++ b/nessus/scans_export_status_test.go
@@ -1,0 +1,151 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansExportStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		fileID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			fileID:  100,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			fileID:  200,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			fileID:  100,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			fileID:  100,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			fileID:  100,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			fileID:  100,
+			wantErr: true,
+		},
+		{
+			name: "error with negative file ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			fileID:  -100,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			fileID:  100,
+			wantErr: true,
+		},
+		{
+			name: "error with zero file ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			fileID:  0,
+			wantErr: true,
+		},
+		{
+			name: "error with large scan ID and file ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  999999999,
+			fileID:  999999999,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansExportStatus(tt.scanID, tt.fileID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansExportStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (got == nil || got.Status == "") {
+				t.Errorf("ScansExportStatus() got = %v, want non-nil Status", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_host_details_test.go
+++ b/nessus/scans_host_details_test.go
@@ -1,0 +1,138 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansHostDetails(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   []Option
+		pathParam *ScansHostDetailsPathParams
+		query     *ScansHostDetailsQuery
+		wantErr   bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: 100},
+			query:     &ScansHostDetailsQuery{HistoryID: 0},
+			wantErr:   false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 2, HostID: 200},
+			query:     &ScansHostDetailsQuery{HistoryID: 0},
+			wantErr:   false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: 100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: 100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: 100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: -1, HostID: 100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with negative host ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: -100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 0, HostID: 100},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with zero host ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansHostDetailsPathParams{ScanID: 1, HostID: 0},
+			query:     &ScansHostDetailsQuery{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansHostDetails(tt.pathParam, tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansHostDetails() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansHostDetails() got = %v, want non-nil", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_kill_test.go
+++ b/nessus/scans_kill_test.go
@@ -1,0 +1,100 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansKill(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansKill(tt.scanID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansKill() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_launch_test.go
+++ b/nessus/scans_launch_test.go
@@ -1,0 +1,112 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansLaunch(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		request *ScansLaunchRequest
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: &ScansLaunchRequest{AltTargets: []string{"192.168.1.1"}},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			request: &ScansLaunchRequest{AltTargets: []string{"10.0.0.1"}},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			request: &ScansLaunchRequest{AltTargets: []string{"192.168.1.1"}},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			request: &ScansLaunchRequest{AltTargets: []string{"192.168.1.1"}},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			request: &ScansLaunchRequest{AltTargets: []string{"192.168.1.1"}},
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			request: &ScansLaunchRequest{AltTargets: []string{"192.168.1.1"}},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: nil,
+			wantErr: false, // Accepts nil request, server may handle validation
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansLaunch(tt.scanID, tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansLaunch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (got == nil || got.ScanUUID == "") {
+				t.Errorf("ScansLaunch() got = %v, want non-nil ScanUUID", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_list_test.go
+++ b/nessus/scans_list_test.go
@@ -12,38 +12,92 @@ func TestClient_ScansList(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "success",
+			name: "success with valid API key",
 			options: []Option{
 				WithAPIURL("https://localhost:8834"),
 				WithAPIKey(
-					"ede55bc4fbad66a41a46f4a5ff35500e7485adae1bc5d94d98e9a1c1f7bb0ecc",
-					"af2ca8def3fa67705e38ded764d3c282fb7f82a516883bb4f1e310aba02f1e1b",
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
 				),
 			},
+			query:   &ScansListQuery{FolderID: 1},
 			wantErr: false,
 		},
 		{
-			name: "error",
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			query:   &ScansListQuery{FolderID: 2},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			query:   &ScansListQuery{FolderID: 1},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			query:   &ScansListQuery{FolderID: 1},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
 			options: []Option{
 				WithAPIURL("https://localhost:8834"),
 			},
+			query:   &ScansListQuery{FolderID: 1},
+			wantErr: true,
+		},
+		{
+			name: "success with nil query",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			query:   nil,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid folder ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			query:   &ScansListQuery{FolderID: -1},
 			wantErr: true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewClient(tt.options...)
 			if err != nil {
 				t.Errorf("NewClient() error = %v", err)
+				return
 			}
-
 			got, err := c.ScansList(tt.query)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScansList() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != nil && len(got.Scans) == 0 && len(got.Folders) == 0 {
-				t.Errorf("ScansList() got = %v", got)
+			if !tt.wantErr && (got == nil || (len(got.Scans) == 0 && len(got.Folders) == 0)) {
+				t.Errorf("ScansList() got = %v, want non-nil scans or folders", got)
 			}
 		})
 	}

--- a/nessus/scans_pause_test.go
+++ b/nessus/scans_pause_test.go
@@ -1,0 +1,100 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansPause(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansPause(tt.scanID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansPause() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_plugin_output_test.go
+++ b/nessus/scans_plugin_output_test.go
@@ -1,0 +1,164 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansPluginOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		options   []Option
+		pathParam *ScansPluginOutputPathParams
+		query     *ScansPluginOutputQuery
+		wantErr   bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{HistoryID: 0},
+			wantErr:   false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 2, HostID: 200, PluginID: 3000},
+			query:     &ScansPluginOutputQuery{HistoryID: 0},
+			wantErr:   false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: -1, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with negative host ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: -100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with negative plugin ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: -2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 0, HostID: 100, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with zero host ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 0, PluginID: 2000},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+		{
+			name: "error with zero plugin ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			pathParam: &ScansPluginOutputPathParams{ScanID: 1, HostID: 100, PluginID: 0},
+			query:     &ScansPluginOutputQuery{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansPluginOutput(tt.pathParam, tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansPluginOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansPluginOutput() got = %v, want non-nil", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_read_status_test.go
+++ b/nessus/scans_read_status_test.go
@@ -1,0 +1,121 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansReadStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		request *ScansReadStatusRequest
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			request: &ScansReadStatusRequest{Read: false},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			request: &ScansReadStatusRequest{Read: true},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansReadStatus(tt.scanID, tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansReadStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_resume_test.go
+++ b/nessus/scans_resume_test.go
@@ -1,0 +1,100 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansResume(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansResume(tt.scanID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansResume() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/scans_schedule_test.go
+++ b/nessus/scans_schedule_test.go
@@ -1,0 +1,125 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansSchedule(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		request *ScansScheduleRequest
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			request: &ScansScheduleRequest{Enabled: false},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			request: &ScansScheduleRequest{Enabled: true},
+			wantErr: true,
+		},
+		{
+			name: "error with nil request",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			request: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			got, err := c.ScansSchedule(tt.scanID, tt.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansSchedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ScansSchedule() got = %v, want non-nil", got)
+			}
+		})
+	}
+}

--- a/nessus/scans_stop_test.go
+++ b/nessus/scans_stop_test.go
@@ -1,0 +1,100 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_ScansStop(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		scanID  int
+		wantErr bool
+	}{
+		{
+			name: "success with valid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  1,
+			wantErr: false,
+		},
+		{
+			name: "success with valid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("06b2f2a7c5b7cf2c7bee97971f8e7393d06dc0ff7b982c6f"),
+			},
+			scanID:  2,
+			wantErr: false,
+		},
+		{
+			name: "error with invalid API key",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey("invalid", "invalid"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with invalid session token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid-token"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			scanID:  1,
+			wantErr: true,
+		},
+		{
+			name: "error with negative scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  -1,
+			wantErr: true,
+		},
+		{
+			name: "error with zero scan ID",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			scanID:  0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+				return
+			}
+			err = c.ScansStop(tt.scanID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ScansStop() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/nessus/session_password.go
+++ b/nessus/session_password.go
@@ -12,11 +12,8 @@ type SessionPasswordRequest struct {
 	CurrentPassword string `json:"current_password"`
 }
 
-func (c *Client) SessionPassword(password string, currentPassword string) error {
-	reqBody, err := sonic.Marshal(&SessionPasswordRequest{
-		Password:        password,
-		CurrentPassword: currentPassword,
-	})
+func (c *Client) SessionPassword(req *SessionPasswordRequest) error {
+	reqBody, err := sonic.Marshal(req)
 	if err != nil {
 		return err
 	}

--- a/nessus/session_password_test.go
+++ b/nessus/session_password_test.go
@@ -1,0 +1,108 @@
+package nessus
+
+import (
+	"testing"
+)
+
+func TestClient_SessionPassword(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		req     *SessionPasswordRequest
+		wantErr bool
+	}{
+		{
+			name: "success with token",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("065954a9a9fc43d3b964c1755e036367424a0ade6005aa6c"),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "123456aA",
+				CurrentPassword: "Abcd1234",
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with api keys",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithAPIKey(
+					"06ea945d67266e66fe6979aa448c321a6624048f6a3480cde000dad76e7ef921",
+					"a306b9ff56069c37b3f2ee120358cac809d77f159a1cf796eb1df64f783eea91",
+				),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "123456aA",
+				CurrentPassword: "Abcd1234",
+			},
+			wantErr: false,
+		},
+		{
+			name: "error with invalid credentials",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("invalid_token"),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "123456aA",
+				CurrentPassword: "Abcd1234",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with empty password",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("065954a9a9fc43d3b964c1755e036367424a0ade6005aa6c"),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "",
+				CurrentPassword: "Abcd1234",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with empty current password",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+				WithToken("065954a9a9fc43d3b964c1755e036367424a0ade6005aa6c"),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "123456aA",
+				CurrentPassword: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with no authentication",
+			options: []Option{
+				WithAPIURL("https://localhost:8834"),
+			},
+			req: &SessionPasswordRequest{
+				Password:        "123456aA",
+				CurrentPassword: "Abcd1234",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			if err != nil {
+				t.Errorf("NewClient() error = %v", err)
+			}
+
+			if err := c.SessionPassword(tt.req); (err != nil) != tt.wantErr {
+				t.Errorf("SessionPassword() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				c.SessionPassword(&SessionPasswordRequest{
+					Password:        "Abcd1234",
+					CurrentPassword: "123456aA",
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several Nessus client methods related to scan and plugin management, and makes a minor field renaming in the scan creation request struct. The new tests cover a wide range of success and error scenarios, improving the reliability and maintainability of the codebase.

**Major changes include:**

### Test Coverage Additions

* Added unit tests for `PluginsPluginDetails`, covering valid/invalid credentials, plugin IDs, network errors, and HTTP errors in `nessus/plugins_plugin_details_test.go`.
* Added unit tests for `ScansAttachmentPrepare`, testing various parameter combinations, authentication methods, and error conditions in `nessus/scans_attachment_prepare_test.go`.
* Added unit tests for `ScansCopy`, including different authentication methods, invalid IDs, and request validation in `nessus/scans_copy_test.go`.
* Added unit tests for `ScansCreate`, covering both successful and error scenarios for scan creation in `nessus/scans_create_test.go`.
* Added unit tests for `ScansDeleteBulk` and `ScansDeleteHistory`, testing bulk deletion and history deletion with various credentials and ID values in `nessus/scans_delete_bulk_test.go` and `nessus/scans_delete_history_test.go`. [[1]](diffhunk://#diff-5398cdb44d6dde317dbbb4b546ff591e197f3c40403aea8fb6ab5606bbeea1a4R1-R104) [[2]](diffhunk://#diff-200eb35fba3bff2da08241d456ffcf5a32896019263ed775a5f08e3b1e7691f9R1-R108)

### Minor Struct Update

* Renamed the `UUID` field to `TemplateUUID` in the `ScansCreateRequest` struct, and corrected the capitalization of `CreationDate` in the `ScanResult` struct for naming consistency in `nessus/scans_create.go`.